### PR TITLE
Add ability to enable webpack-powered "include"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ var template = require("jade!./file.jade");
 Don't forget to polyfill `require` if you want to use it in node.
 See `webpack` documentation.
 
+### Webpack-powered includes
+
+```
+var template = require("jade?webpackInclude=1!./file.jade");
+```
+
+This will convert all `include` statements in the template to webpack-enabled
+require statements. This is useful if you have prefilters that you want to apply
+to the included templates.
+
+It also has the effect of de-duplicating sub-templates that are included in
+multiple places.
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,27 @@ module.exports = function(source) {
   // Get filename without any loaders
 	var req = loaderUtils.getRemainingRequest(this).split("!").pop();
 	var query = loaderUtils.parseQuery(this.query);
+
+  // Replace "include" statements with webpack-powered require()
+  if (query.webpackInclude) {
+    jade.Parser.prototype._parseInclude = jade.Parser.prototype.parseInclude;
+    jade.Parser.prototype.parseInclude = function () {
+      var rel = this.expect('include').val.trim();
+      var dir = path.dirname(this.filename);
+
+      // no extension
+      if (!~path.basename(rel).indexOf('.')) {
+        rel += '.jade';
+      }
+
+      var abs = path.join(dir, rel);
+      var call = 'require("'+abs+'")(locals)';
+      var node = new jade.nodes.Code(call, true, false);
+      node.line = this.line();
+      return node;
+    };
+  }
+
 	var tmplFunc = jade.compile(source, {
 		filename: req,
 		client: true,
@@ -22,6 +43,11 @@ module.exports = function(source) {
 		locals: query.locals,
 		compileDebug: this.debug || false
 	});
+
+  if (query.webpackInclude) {
+    jade.Parser.prototype.parseInclude = jade.Parser.prototype._parseInclude;
+  }
+
 	var debugSource = "";
 	if(this.debug) {
 		debugSource = "require(" + JSON.stringify(path.join(__dirname, "web_modules", "fs")) + ").setFile(" + JSON.stringify(req) + ", " + JSON.stringify(source) + ");";

--- a/index.js
+++ b/index.js
@@ -4,11 +4,15 @@
 */
 var path = require("path");
 var loaderUtils = require("loader-utils");
+
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var jade = require("jade");
+
 	var runtime = "var jade = require("+JSON.stringify(path.join(__dirname, "node_modules", "jade", "lib", "runtime"))+");\n\n";
-	var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
+
+  // Get filename without any loaders
+	var req = loaderUtils.getRemainingRequest(this).split("!").pop();
 	var query = loaderUtils.parseQuery(this.query);
 	var tmplFunc = jade.compile(source, {
 		filename: req,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "jade loader module for webpack",
 	"dependencies": {
 		"loader-utils": "0.2.x",
-		"jade": "0.28.x"
+		"jade": "0.35.x"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
The Jade template language has an `include` statement which normally statically merges a sub-template into the current template. (It actually does this at parse time, i.e. very early in the compilation process.)

When I tried to create a webpack pre-filter for Jade templates, I ran into a number of issues. This pull request represents my solutions.
1. Includes would fail entirely, because `jade-loader` would not strip the filename correctly if there were other filters. Not sure if my fix is correct, please review. See 0ebc13ccdd56af7c65cbb847c0e6e123339e2e44.
2. Since the include is applied without webpack being aware of it at all, the filters etc. don't get applied to the subtemplates. After trying a few approaches towards solving this, I found one that seems to work very well and is extremely powerful: Translating `include file.jade` tags into `!= require('file.jade')(locals)` lines.
   
   What this does is it delegates the actual job of including the sub-template to webpack's `require`. This means that pre-filters etc. all work perfectly and sub-templates that are included in multiple places are only shipped once in the compiled code.
   
   However, this does cause a few regressions, so I've made it optional, disabled by default:
   - Will break if you have a template variable called `locals`.
   - Will break if your templates contain JS code that relies on the static compilation behavior somehow.
   - Might break with future versions of Jade, since we're monkey-patching the parser. (Although I'm doing it as cleanly as possible.)
