### PR TITLE
added repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
 	"scripts": {
 		"test": "mocha -R spec"
 	},
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/jade-loader.git"
+    },
 	"licenses": [
 		{
 			"type": "MIT",


### PR DESCRIPTION
This silences the noisy npm install warning “npm WARN package.json jade-loader@0.6.1 No repository field.”
