### PR TITLE
make `extends` and `include` use aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,14 @@ module.exports = function(source) {
 	MyParser.prototype.constructor = MyParser;
 
 	var missingFileMode = false;
+	var aliases = ((this.options || {}).resolve || {}).alias || {};
 	function getFileContent(context, request) {
+		var array = request.split('/');
+		var alias = array.shift();
+		if (aliases[alias]) {
+			context = aliases[alias];
+			request = array.join('/');
+		}
 		request = /^~/.test(request) ? request.substr(1) : "./" + request;
 		var baseRequest = request;
 		var filePath = filePaths[context + " " + request];

--- a/index.js
+++ b/index.js
@@ -33,13 +33,15 @@ module.exports = function(source) {
 	MyParser.prototype.constructor = MyParser;
 
 	var missingFileMode = false;
-	var aliases = ((this.options || {}).resolve || {}).alias || {};
+	var aliases = ((this.options || {}).resolve || {}).alias;
 	function getFileContent(context, request) {
-		var array = request.split('/');
-		var alias = array.shift();
-		if (aliases[alias]) {
-			context = aliases[alias];
-			request = array.join('/');
+		if (aliases) {
+			var array = request.split('/');
+			var alias = array.shift();
+			if (aliases[alias]) {
+				context = aliases[alias];
+				request = array.join('/');
+			}
 		}
 		request = /^~/.test(request) ? request.substr(1) : "./" + request;
 		var baseRequest = request;


### PR DESCRIPTION
Hi,
here is a pull request that allow using `resolve.alias` inside templates

``` javascript
resolve: {
  alias: {
    views: __dirname + '/some/long/path/to/templates'
  }
}
```

``` jade
extends views/layout
include views/mixins
```
