### PR TITLE
update jade dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"loader-utils": "0.2.x"
 	},
 	"peerDependencies": {
-		"jade": "^1.2.0"
+		"jade": "^1.7.0"
 	},
 	"devDependencies": {
 		"mocha": "*",


### PR DESCRIPTION
1.7.0 is most recent. npm install is failing unless you specify 1.2.x. @sokra 
