### PR TITLE
provide require syntax for jade includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ These parameters are passed to [jade options](http://jade-lang.com/api/):
 - `pretty`
 - `locals`
 
-the `root` parameter is used for the `urlToRequest()` function of the
-[loader-utils module](https://github.com/webpack/loader-utils#root-relative-urls)
+The `root` parameter is used for the `urlToRequest()` function of the
+[loader-utils module](https://github.com/webpack/loader-utils#root-relative-urls).
 
+If `requireSyntax` is __true__ then all the jade `include` calls will be handled like `require()` calls (a `~` will be prepended automatically).
+Relative jade files cannot be included by `include form-view` anymore, instead you MUST use
+`include ./form-view`.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ div
 
 You need to configure loaders for these filetypes too. (Take a look at the [file-loader](https://github.com/webpack/file-loader).)
 
+### Query parameters
+
+These parameters are passed to [jade options](http://jade-lang.com/api/):
+- `self`
+- `globals`
+- `pretty`
+- `locals`
+
+the `root` parameter is used for the `urlToRequest()` function of the
+[loader-utils module](https://github.com/webpack/loader-utils#root-relative-urls)
+
+
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -35,9 +35,7 @@ module.exports = function(source) {
 	var missingFileMode = false;
 	function getFileContent(context, request) {
 		if (query.requireSyntax) {
-			if (/^[^.~\/]/.test(request)) {
-				request = '~'+request;
-			}
+			if (/^[^.~\/]/.test(request)) request = '~' + request;
 		}
 		request = loaderUtils.urlToRequest(request, query.root);
 		var baseRequest = request;

--- a/index.js
+++ b/index.js
@@ -34,7 +34,12 @@ module.exports = function(source) {
 
 	var missingFileMode = false;
 	function getFileContent(context, request) {
-		request = loaderUtils.urlToRequest(request, query.root)
+		if (query.requireSyntax) {
+			if (/^[^.~\/]/.test(request)) {
+				request = '~'+request;
+			}
+		}
+		request = loaderUtils.urlToRequest(request, query.root);
 		var baseRequest = request;
 		var filePath = filePaths[context + " " + request];
 		if(filePath) return filePath;


### PR DESCRIPTION
This pull request allows to write jade includes without the `~` to load from the module and root directory.
This should not break anything because you need to enable this feature it via the query.
IMO it's really sad, that jade doesn't provide this out of the box.

The problem with `~` is that we try to migrating our app to webpack (step by step), but if we would use `~` it would break some things in our current build process (while the migration is not completed)

So this PR don't force users to use some special syntax for module relative include paths, instead they can use a common way to do that.

I also added the other query params in the readme
