### PR TITLE
Doctype option added - Fixes #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,6 +174,7 @@ module.exports = function(source) {
 				globals: ["require"].concat(query.globals || []),
 				pretty: query.pretty,
 				locals: query.locals,
+				doctype: query.doctype || 'html',
 				compileDebug: loaderContext.debug || false
 			});
 		} catch(e) {


### PR DESCRIPTION
Caution: I set HTML5 as default doctype.

Usage:

```
{test: /\.jade$/, loader: 'jade?doctype=xhtml', exclude: /node_modules/}
```

Fixes #19 
