### PR TITLE
Added support for compiling static HTML with '+static' query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 ``` javascript
 var template = require("jade!./file.jade");
 // => returns file.jade content as template function
+
+var template = require("jade?+static!./file.jade");
+// => returns file.jade content as static html
 ```
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)

--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ module.exports = function(source) {
 
 		if ('indent' == this.peek().type) {
 			ast.includeBlock().push(this.block());
-		} else if(!parser._mustBeInlined) {
+		} else if(!parser._mustBeInlined && !query.static) {
 			ast = new nodes.Code("require(" + JSON.stringify(path) + ").call(this, locals)", true, false);
 			ast.line = this.line();
 		}
@@ -167,7 +167,7 @@ module.exports = function(source) {
 	run();
 	function run() {
 		try {
-			var tmplFunc = jade.compileClient(source, {
+			var options = {
 				parser: loadModule ? MyParser : undefined,
 				filename: req,
 				self: query.self,
@@ -175,7 +175,9 @@ module.exports = function(source) {
 				pretty: query.pretty,
 				locals: query.locals,
 				compileDebug: loaderContext.debug || false
-			});
+			};
+
+            var tmplFunc = (!query.static) ? jade.compileClient(source, options) : jade.compile(source, options)
 		} catch(e) {
 			if(missingFileMode) {
 				// Ignore, it'll continue after async action
@@ -184,7 +186,11 @@ module.exports = function(source) {
 			}
 			throw e;
 		}
-		var runtime = "var jade = require("+JSON.stringify(require.resolve("jade/lib/runtime"))+");\n\n";
-		loaderContext.callback(null, runtime + "module.exports = " + tmplFunc.toString());
+        if (!query.static) {
+            var runtime = "var jade = require(" + JSON.stringify(require.resolve("jade/lib/runtime")) + ");\n\n";
+            loaderContext.callback(null, runtime + "module.exports = " + tmplFunc.toString());
+        } else {
+            loaderContext.callback(null, tmplFunc());
+        }
 	}
 }

--- a/test/fakeModuleSystem.js
+++ b/test/fakeModuleSystem.js
@@ -1,7 +1,7 @@
 var fs = require("fs");
 var path = require("path");
 
-module.exports = function runLoader(loader, directory, filename, arg, callback) {
+module.exports = function runLoader(loader, directory, filename, arg, callback, query) {
 	var async = true;
 	var loaderContext = {
 		async: function() {
@@ -10,7 +10,7 @@ module.exports = function runLoader(loader, directory, filename, arg, callback) 
 		},
 		loaders: ["itself"],
 		loaderIndex: 0,
-		query: "",
+		query: query ? query : "",
 		resource: filename,
 		callback: function() {
 			async = true;

--- a/test/fixtures/static/static.jade
+++ b/test/fixtures/static/static.jade
@@ -1,0 +1,1 @@
+p testing compilation to static html 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1,0 +1,22 @@
+var should = require("should");
+
+var fs = require("fs");
+var path = require("path");
+
+var runLoader = require("./fakeModuleSystem");
+var jadeLoader = require("../");
+
+var fixtures = path.join(__dirname, "fixtures/static");
+
+describe("render", function() {
+	it("should render static HTML", function(done) {
+		var template = path.join(fixtures, "static.jade");
+		runLoader(jadeLoader, path.join(fixtures, "extend"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+			if(err) throw err;
+
+			result.should.have.type("string");
+			result.should.match(/^<p>testing compilation to static html <\/p>$/);
+			done();
+		}, "?static=1");
+	});
+});


### PR DESCRIPTION
Just another variant of [PR#21](https://github.com/webpack/jade-loader/pull/21).
Fixes 'require is not defined' error in PR#21
