### PR TITLE
Static templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ var template = require("jade!./file.jade");
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
+### Pre-render templates
+Paired with the [apply-loader](https://github.com/mogelbrod/apply-loader), produce static templates:
+
+```javascript
+var template = require("apply!jade!./file.jade");
+// => returns file.jade content as template string
+```
+
+#### Passing locals
+```javascript
+var locals = {
+	city: 'New York'
+};
+var template = require("apply?{obj: ${JSON.stringify(locals)}}!jade!./file.jade");
+// => returns file.jade content as template string rendered with template options
+```
+
 ### Embedded resources
 
 Try to use `require` for all your embedded resources, to process them with webpack.

--- a/index.js
+++ b/index.js
@@ -173,7 +173,6 @@ module.exports = function(source) {
 				self: query.self,
 				globals: ["require"].concat(query.globals || []),
 				pretty: query.pretty,
-				locals: query.locals,
 				doctype: query.doctype || 'html',
 				compileDebug: loaderContext.debug || false
 			});


### PR DESCRIPTION
- Adds examples to README of how to render static html using the excellent solution in https://github.com/webpack/jade-loader/issues/15#issuecomment-149248913. This example is difficult to find (in a long closed issue) and needs to be put in the README. There's clearly demand for this functionality:
  
  There are currently two open PRs about creating static templates, which could be closed:
  - https://github.com/webpack/jade-loader/pull/26
  - https://github.com/webpack/jade-loader/pull/21
- Removes passing of `locals` to `jade.compileClient` to reduce confusion about how render static templates using locals.
