### PR TITLE
Include npm package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # jade loader for webpack
 
+```
+npm install jade-loader --save-dev
+```
+
 ## Usage
 
 ``` javascript


### PR DESCRIPTION
It is not clear what the npm package name is from the readme, you would either has to guess, go to npmjs.org or go to the package.json and look it up.

This makes it easier when you are just looking it up quick with google.
