### PR TITLE
allow usage of custom filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,12 @@ module.exports = function(source) {
 	var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
 
 	var query = loaderUtils.parseQuery(this.query);
+	
+	if (query.filters) {
+		query.filters.forEach((filterObj) => {
+			jade.filters[filterObj.name] = filterObj.filter
+		});
+	}
 
 	var loadModule = this.loadModule;
 	var resolve = this.resolve;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(source) {
 	
 	if (query.filters) {
 		query.filters.forEach((filterObj) => {
-			jade.filters[filterObj.name] = filterObj.filter
+			jade.filters[filterObj.name] = eval(filterObj.filter);
 		});
 	}
 


### PR DESCRIPTION
This change would allow the use of custom filters in jade files.

in webpack.config.js:

``` js
{
  test: /\.jade$/,
  loader: 'jade',
  query: {
    filters: [
      {
        name: 'babel',
        filter: 'require("jade-babel")({})' // according to my tests webpack queries cannot contain functions so this will be `eval()`d later
      },
      {
        name: 'scss',
        filter: 'jstransformer(require("jstransformer-scss"))'
      }
    ]
  }
},
```
