### PR TITLE
Use recommended method for getting loader config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(source) {
 
 	var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
 
-	var query = loaderUtils.parseQuery(this.query);
+	var query = loaderUtils.getLoaderConfig(this, 'pug');
 
 	var loadModule = this.loadModule;
 	var resolve = this.resolve;


### PR DESCRIPTION
I haven't tested this, but https://www.npmjs.com/package/loader-utils#getloaderconfig seems to suggest that we should be using this method, rather than directly parsing the query.  Maybe this will solve pugjs/pug-lexer#69

Another possibility is that we should be directly accepting options as an argument to a function?  I don't know how this is normally handled, but we can't have all our options JSONified.
