### PR TITLE
Propagate async errors to webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,8 @@ module.exports = function(source) {
 				missingFileMode = false;
 				return;
 			}
-			throw e;
+			loaderContext.callback(e);
+			return;
 		}
 		var runtime = "var pug = require(" + loaderUtils.stringifyRequest(loaderContext, "!" + modulePaths.runtime) + ");\n\n";
 		loaderContext.callback(null, runtime + tmplFunc.toString() + ";\nmodule.exports = template;");

--- a/test/extend+error.test.js
+++ b/test/extend+error.test.js
@@ -1,0 +1,19 @@
+var should = require("should");
+
+var fs = require("fs");
+var path = require("path");
+
+var runLoader = require("./fakeModuleSystem");
+var pugLoader = require("../");
+
+var fixtures = path.join(__dirname, "fixtures");
+
+describe("extend+error", function() {
+	it("should propagate async errors to Webpack", function(done) {
+		var template = path.join(fixtures, "extend+error", "error.pug");
+		runLoader(pugLoader, path.join(fixtures, "extend+error"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+			should(err).be.not.null();
+			done();
+		});
+	});
+});

--- a/test/fakeModuleSystem.js
+++ b/test/fakeModuleSystem.js
@@ -2,7 +2,7 @@ var fs = require("fs");
 var path = require("path");
 
 module.exports = function runLoader(loader, directory, filename, arg, callback) {
-	var async = true;
+	var async = false;
 	var loaderContext = {
 		async: function() {
 			async = true;
@@ -17,16 +17,26 @@ module.exports = function runLoader(loader, directory, filename, arg, callback) 
 			async = true;
 			return callback.apply(this, arguments);
 		},
-		resolve: function(context, request, callback) {
-			callback(null, path.resolve(context, request));
+		resolve: function(context, request, resolveCallback) {
+			process.nextTick(function() {
+				resolveCallback(null, path.resolve(context, request));
+			});
 		},
-		loadModule: function(request, callback) {
+		loadModule: function(request, loadCallback) {
 			request = request.replace(/^-?!+/, "");
 			request = request.split("!");
-			var content = fs.readFileSync(request.pop(), "utf-8");
-			if(request[0] && /stringify/.test(request[0]))
-				content = JSON.stringify(content);
-			return callback(null, content);
+			fs.readFile(request.pop(), 'utf-8', function(err, content) {
+				if (err) {
+					loadCallback(err);
+					return;
+				}
+
+				if(request[0] && /stringify/.test(request[0])) {
+					content = JSON.stringify(content);
+				}
+
+				loadCallback(null, content);
+			});
 		}
 	};
 	var res = loader.call(loaderContext, arg);

--- a/test/fixtures/extend+error/error.pug
+++ b/test/fixtures/extend+error/error.pug
@@ -1,0 +1,3 @@
+extend /parent.pug
+
+p This will cause an error

--- a/test/fixtures/extend+error/parent.pug
+++ b/test/fixtures/extend+error/parent.pug
@@ -1,0 +1,2 @@
+block output
+	p This might not see the light of day


### PR DESCRIPTION
When compiling a module that has asynchronous errors (e.g. when an error results from using `extend` or `include`), the error will not go through Webpack, but will be thrown in some async handler somewhere.

This has two pretty big drawbacks:
- When watching files for changes, the entire process will exit when an error is thrown, as opposed to continuing and waiting for the error to be fixed (this is a deal breaker)
- The error does not go through Webpack's error reporting, which some tools may leverage.

I've fixed this by making all thrown errors in the `run` function go through the Webpack callback. I've added tests to check that this behaviour works, and I have verified that it fixed the problem in a project I am using `pug-loader` in.

I had to modify the mock Webpack loader system to actually be asynchronous, all tests should still be passing.

**Edit:** Turns out this fixes https://github.com/pugjs/pug-loader/issues/77 as well