### PR TITLE
Fix pug dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "resolve": "^1.1.7"
   },
   "peerDependencies": {
-    "pug": ">=2.0.0-beta3 <3"
+    "pug": ">=2.0.0-beta <3"
   },
   "devDependencies": {
     "mocha": "*",
-    "pug": "^2.0.0-beta4",
+    "pug": "^2.0.0-beta",
     "should": "*"
   },
   "scripts": {


### PR DESCRIPTION
Currently, running
``` 
npm i pug-loader 
```
Fails with:
```
npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! peer invalid: pug@>=2.0.0-beta3 <3, required by pug-loader@2.3.0
```