### PR TITLE
Make usage example compatible with webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pug loader for Webpack.
 ## Usage
 
 ``` javascript
-var template = require("pug!./file.pug");
+var template = require("pug-loader!./file.pug");
 // => returns file.pug content as template function
 
 // or, if you've bound .pug to pug-loader


### PR DESCRIPTION
https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed