### PR TITLE
fix DeprecationWarning: loaderUtils.parseQuery() received a non-strin…

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(source) {
 
 	var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
 
-	var query = loaderUtils.getLoaderConfig(this, "pugLoader");
+	var query = loaderUtils.getOptions(this);
 
 	var loadModule = this.loadModule;
 	var resolve = this.resolve;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Timothy Gu <timothygu99@gmail.com>"
   ],
   "dependencies": {
-    "loader-utils": "~0.2.5",
+    "loader-utils": "^1.1.0",
     "pug-walk": "^1.0.0",
     "resolve": "^1.1.7"
   },


### PR DESCRIPTION
`DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56`

link: webpack/loader-utils#56