### PR TITLE
Fix the version bug by removing the unnecessary zero-dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pug-loader",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Tobias Koppers @sokra",
   "description": "Pug loader module for webpack",
   "maintainers": [
@@ -12,7 +12,7 @@
     "resolve": "^1.1.7"
   },
   "peerDependencies": {
-    "pug": ">=2.0.0-beta <3"
+    "pug": ">=2 <3"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pug-loader",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "author": "Tobias Koppers @sokra",
   "description": "Pug loader module for webpack",
   "maintainers": [
@@ -12,11 +12,11 @@
     "resolve": "^1.1.7"
   },
   "peerDependencies": {
-    "pug": ">=2 <3"
+    "pug": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "*",
-    "pug": "^2.0.0-beta",
+    "pug": "^2.0.0",
     "should": "*"
   },
   "scripts": {


### PR DESCRIPTION
Node errors and tests resolve without warnings by changing `>=2.0.0-beta` to `>=2`.

See https://github.com/npm/node-semver#advanced-range-syntax.
This issue also relates to dev-deps and peer-deps #76, #79 and pugjs/pug/issues/2720. 