### PR TITLE
Handle null result of loaderUtils.getOptions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(source) {
 
 	var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
 
-	var query = loaderUtils.getOptions(this);
+	var query = loaderUtils.getOptions(this) || {};
 
 	var loadModule = this.loadModule;
 	var resolve = this.resolve;


### PR DESCRIPTION
Simple fix, but essential for Webpack 4 combatability.