### PR TITLE
Allow for Pug 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pug-loader",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "Tobias Koppers @sokra",
   "description": "Pug loader module for webpack",
   "maintainers": [
@@ -12,7 +12,7 @@
     "resolve": "^1.1.7"
   },
   "peerDependencies": {
-    "pug": "^2.0.0"
+    "pug": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This has stagnated for quite a while, and even with the latest and greatest Yarn 2 tricks this outdated peer dependency just won't be quiet, despite many years (?) of people using pug 3 without issue just fine.